### PR TITLE
fixing curly quote

### DIFF
--- a/SVM_Final.R
+++ b/SVM_Final.R
@@ -31,7 +31,7 @@ library(ROCR)
 library(kernlab)
 
 #Data Processing and Visualization:
-setwd("workshop_files“) 
+setwd("workshop_files") 
 
 #Reading the dataset for more information about the dataset description, please visit: "http://archive.ics.uci.edu/ml",
 wdbc <- read.csv('WDBC.csv',head=T)


### PR DESCRIPTION
There was a curly quote in the setwd() command that caused problems for the script.